### PR TITLE
Removing local file deletion feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wappsto-cli",
   "description": "Command Line Interface for creating wapps in Wappsto",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "Apache-2.0",
   "main": "dist/wappsto-cli.cjs.production.min.js",
   "module": "dist/wappsto-cli.esm.js",

--- a/src/util/questions.ts
+++ b/src/util/questions.ts
@@ -149,13 +149,13 @@ class Questions {
   ): Promise<JsonObjType | false> {
     let newWapp = true;
     if (present) {
-      tui.showWarning('It seams like you already have a wapp in this folder!');
+      tui.showWarning('It seems like you already have a wapp in this folder!');
       const override = await this.ask([
         {
           name: 'override',
           type: 'confirm' as const,
           initial: () => false,
-          message: 'Do you want to delete your local wapp?',
+          message: 'Do you want to replace your local wapp with a new one?',
         },
       ]);
       if (override === false) {
@@ -655,19 +655,8 @@ class Questions {
       {
         name: 'del',
         type: 'confirm' as const,
-        message: 'Do you want to delete the Wapp?',
-        initial: false,
-      },
-      {
-        name: 'local',
-        type: (prev: JsonObjType) => (prev ? 'confirm' : null),
-        message: 'Do you want to delete the local files?',
-      },
-      {
-        name: 'remote',
-        type: (prev: JsonObjType, values: JsonObjType) =>
-          values.del ? 'confirm' : null,
         message: 'Do you want to delete the Wapp on Wappsto?',
+        initial: false,
       },
     ]);
   }
@@ -782,17 +771,6 @@ class Questions {
             value: 'abort',
           },
         ],
-      },
-    ]);
-  }
-
-  askDeleteLocalFile(file: string): Promise<Answers<string> | false> {
-    return this.ask([
-      {
-        name: 'delete',
-        type: 'confirm' as const,
-        initial: true,
-        message: `${file} was deleted on the server, do you want to delete the local file?`,
       },
     ]);
   }

--- a/src/wapp.delete.ts
+++ b/src/wapp.delete.ts
@@ -19,35 +19,24 @@ export default class DeleteWapp extends Wapp {
       return;
     }
 
-    if (!answers.local && !answers.remote) {
-      tui.showWarning('Nothing to delete');
-      return;
-    }
+    await section('Deleting wapp', async () => {
+      const results = [];
 
-    section('Deleting wapp', async () => {
-      if (answers.local) {
-        this.deleteLocal();
+      this.application.version.forEach((v: Version | string) => {
+        if (typeof v !== 'string' && v.id) {
+          results.push(v.delete());
+          results.push(this.installation.deleteById(v.id));
+        }
+      });
+
+      if (this.application.id) {
+        results.push(this.application.delete());
       }
-
-      if (answers.remote) {
-        const results = [];
-
-        this.application.version.forEach((v: Version | string) => {
-          if (typeof v !== 'string' && v.id) {
-            results.push(v.delete());
-            results.push(this.installation.deleteById(v.id));
-          }
-        });
-
-        if (this.application.id) {
-          results.push(this.application.delete());
-        }
-        try {
-          await Promise.all(results);
-        } catch (err) {
-          tui.showError(`Failed to delete wapp: ${err}`);
-          return;
-        }
+      try {
+        await Promise.all(results);
+      } catch (err) {
+        tui.showError(`Failed to delete wapp: ${err}`);
+        return;
       }
     });
 

--- a/src/wapp.delete.ts
+++ b/src/wapp.delete.ts
@@ -25,8 +25,7 @@ export default class DeleteWapp extends Wapp {
     }
 
     await section('Deleting wapp', async () => {
-      if (answers.remote) {
-        const results = [];
+      const results: Promise<void>[] = [];
 
       this.application.version.forEach((v: Version | string) => {
         if (typeof v !== 'string' && v.id) {
@@ -35,11 +34,11 @@ export default class DeleteWapp extends Wapp {
         }
       });
 
-        if (this.application.id) {
-          results.push(this.application.delete());
-        }
+      await Promise.allSettled(results);
+
+      if (this.application.id) {
         try {
-          await Promise.all(results);
+          await this.application.delete();
         } catch (err) {
           tui.showError(`Failed to delete wapp: ${err}`);
           return;

--- a/src/wapp.delete.ts
+++ b/src/wapp.delete.ts
@@ -34,7 +34,12 @@ export default class DeleteWapp extends Wapp {
         }
       });
 
-      await Promise.allSettled(results);
+      try {
+        await Promise.all(results);
+      } catch (err) {
+        tui.showError(`Failed to delete version/installation: ${err}`);
+        return;
+      }
 
       if (this.application.id) {
         try {

--- a/src/wapp.update.ts
+++ b/src/wapp.update.ts
@@ -180,19 +180,6 @@ export default class UpdateWapp extends Wapp {
           runAsync('delete', file, (file: File) => {
             return file.delete();
           });
-        } else if (!rf && lf && !locallyUpdated) {
-          runAsync('delete', file, async (file: File) => {
-            const answers = await questions.askDeleteLocalFile(file.path);
-            if (answers === false) {
-              /* istanbul ignore next */
-              throw new Error('User aborted');
-            }
-
-            if (answers.delete) {
-              file.status = 'deleted';
-              file.deleteLocal();
-            }
-          });
         }
       }
 


### PR DESCRIPTION
When creating or deleting or performing certain actions in the Wappsto CLI, the user is prompted with the option of deleting the local files for that specific wapp, which is most of the times confusing, since it is rarely something that you would want to do from the CLI