### PR TITLE
Repoint Sentry DSN from self-hosted to SaaS (wirtek-iot, EU)

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,4 +1,4 @@
 [defaults]
-url = https://sentry.iot.seluxit.com
-org = slx
+url = https://de.sentry.io
+org = wirtek-iot
 project = wappsto-cli

--- a/src/util/trace.ts
+++ b/src/util/trace.ts
@@ -24,7 +24,7 @@ try {
 /* istanbul ignore file */
 if (process.env.NODE_ENV !== 'test') {
   Sentry.init({
-    dsn: 'https://ef7592dc40c34510b9246633e453ef0e@sentry.iot.seluxit.com/124',
+    dsn: 'https://f9d10873d36c4079e3981f4a678a73ff@o4511579481702400.ingest.de.sentry.io/4511579709964368',
     integrations: profilingIntegration ? [profilingIntegration] : [],
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control


### PR DESCRIPTION
Self-hosted Sentry (sentry.iot.seluxit.com) is retired for Sentry SaaS in the EU region. Swap DSN(s) to the new SaaS project DSN(s); update sentry-cli org=slx->wirtek-iot and host->de.sentry.io.

NOTE: the committed sentry-cli [auth] token (if any) is a dead self-hosted token; release/sourcemap upload needs a SaaS SENTRY_AUTH_TOKEN in CI.